### PR TITLE
Add helpers for nested models

### DIFF
--- a/pydantic_sql_bridge/utils.py
+++ b/pydantic_sql_bridge/utils.py
@@ -1,7 +1,7 @@
 import sqlite3
 from enum import Enum
 from pydantic import BaseModel, Field
-from typing import Type
+from typing import Type, TypeVar, Union, Any
 
 from sqlglot import Dialects
 
@@ -30,7 +30,7 @@ def get_model_name(table_name: str) -> str:
 
 
 def is_model(field: Field) -> bool:
-    # field.type_ may be something like tuple[str, str] on which issubclass raises a type error
+    # field.annotation may be something like tuple[str, str] on which issubclass raises a type error
     # typing.isclass returns True for this kind of thing though, so try-except it is
     try:
         return issubclass(field.annotation, BaseModel)
@@ -48,3 +48,71 @@ def get_primary_key(model: Type[BaseModel]) -> tuple[str, ...]:
         if any(datum == Annotations.PRIMARY_KEY for datum in field.metadata or []):
             pk_fields.append(name)
     return tuple(pk_fields)
+
+
+NOT_FOUND = object()  # sentinel
+
+
+def lookup_underscored(source: dict, target_name: str) -> Union[NOT_FOUND, Any]:
+    if target_name in source.keys():
+        return source[target_name]
+    matches = [name for name, field in source.items() if target_name.startswith(name)]
+    results = [lookup_underscored(source[name], target_name.removeprefix(f'{name}_')) for name in matches]
+    found = [r for r in results if r is not NOT_FOUND]
+    if len(found) == 0: return NOT_FOUND
+    if len(found) > 1: raise ValueError(f'Ambiguous name matches for {target_name} on {source}, got {results}.')
+    return found[0]
+
+
+T = TypeVar('T', bound=BaseModel)
+
+
+def transform_dict(data: dict, target: Type[T]) -> dict:
+    """
+    Transform `data` to a shape matching with `target`'s attributes, where we map nested models using underscores.
+    i.e. data['address']['street'] in a "nested" dict maps to data['address_street'] in a "flat" one and vice versa.
+    """
+    result = {}
+    errors = []
+    for target_field_name, target_field in target.model_fields.items():
+        if target_field_name in data:
+            result[target_field_name] = data[target_field_name]
+        elif is_model(target_field):
+            field_prefix = target_field.annotation.__name__.lower() + '_'
+            field_source = {k.removeprefix(field_prefix): v for k, v in data.items() if k.startswith(field_prefix)}
+            result[target_field_name] = transform_dict(field_source, target_field.annotation)
+        else:
+            result[target_field_name] = lookup_underscored(data, target_field_name)
+            if result[target_field_name] == NOT_FOUND:
+                errors.append(KeyError(f'Cannot find {target_field_name} in {data}.'))
+    if len(errors) == 1:
+        raise errors[0]
+    elif errors:
+        raise ExceptionGroup(f'Some names cannot be found', errors)
+    return result
+
+
+def dict_to_model(data: dict, model: Type[T]) -> T:
+    errors = []
+    # Convert nested models first
+    for target_name, target_field in model.model_fields.items():
+        if is_model(target_field):
+            try:
+                data[target_name] = dict_to_model(data[target_name], target_field.annotation)
+            except Exception as e:
+                errors.append(e)
+    if len(errors) == 1:
+        raise errors[0]
+    elif errors:
+        raise ExceptionGroup(f'Could not build model {model} from {data}', errors)
+    return model(**data)
+
+
+def transform(model: BaseModel, target: Type[T]) -> T:
+    """
+    Transform `model` to type `target`, where we map nested models using underscores.
+    model.address.street in a "nested" model maps to model.address_street in a "flat" model and vice versa.
+    """
+    target_dict = transform_dict(model.model_dump(), target)
+    return dict_to_model(target_dict, target)
+

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,49 @@
+from pydantic import BaseModel
+
+from pydantic_sql_bridge.utils import transform
+
+
+class First(BaseModel):
+    id: int
+    name: str
+
+
+class Second(BaseModel):
+    id: int
+    score: float
+
+
+class Nested(BaseModel):
+    id: int
+    first: First
+    second: Second
+
+
+class Flat(BaseModel):
+    id: int
+    first_id: int
+    first_name: str
+    second_id: int
+    second_score: float
+
+
+class Mixed(BaseModel):
+    id: int
+    first_id: int
+    first_name: str
+    second: Second
+
+
+def test_transform():
+    nested = Nested(id=0, first=First(id=0, name='alice'), second=Second(id=1, score=-5.21))
+    flat = Flat(id=0, first_id=0, first_name='alice', second_id=1, second_score=-5.21)
+    mixed = Mixed(id=0, first_id=0, first_name='alice', second=Second(id=1, score=-5.21))
+    assert transform(flat, Flat) == flat
+    assert transform(flat, Mixed) == mixed
+    assert transform(flat, Nested) == nested
+    assert transform(mixed, Flat) == flat
+    assert transform(mixed, Mixed) == mixed
+    assert transform(mixed, Nested) == nested
+    assert transform(nested, Flat) == flat
+    assert transform(nested, Mixed) == mixed
+    assert transform(nested, Nested) == nested


### PR DESCRIPTION
It is normal for Pydantic models to have nesting (https://docs.pydantic.dev/latest/concepts/models/#nested-models). However, Pydantic-SQL-bridge only generates flat models.

This PR adds a function `transform` to `pydantic_sql_bridge.utils` that can transform between nested and unnested models, based on their naming scheme (i.e. `person.address.street` gets mapped to `person.address_street` and vice versa). This makes it a little easier to transform query results into a more "natural" form.   
Additionally, this PR updates the README with some explanation around the philosophy of Pydantic-SQL-bridge and why it's not an ORM.